### PR TITLE
토큰 갱신 로직 수정

### DIFF
--- a/app/src/main/java/info/imdang/imdang/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/info/imdang/imdang/ui/splash/SplashViewModel.kt
@@ -3,6 +3,7 @@ package info.imdang.imdang.ui.splash
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import info.imdang.domain.usecase.auth.GetTokenUseCase
+import info.imdang.domain.usecase.auth.ReissueTokenUseCase
 import info.imdang.imdang.base.BaseViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -12,7 +13,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val getTokenUseCase: GetTokenUseCase
+    private val getTokenUseCase: GetTokenUseCase,
+    private val reissueTokenUseCase: ReissueTokenUseCase
 ) : BaseViewModel() {
 
     private val _event = MutableSharedFlow<SplashEvent>()
@@ -26,7 +28,9 @@ class SplashViewModel @Inject constructor(
                 if (accessToken.isNullOrBlank()) {
                     SplashEvent.MoveLoginActivity
                 } else {
-                    SplashEvent.MoveMainActivity
+                    reissueTokenUseCase(Unit)?.let {
+                        SplashEvent.MoveMainActivity
+                    } ?: SplashEvent.MoveLoginActivity
                 }
             )
         }

--- a/data/src/main/java/info/imdang/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/info/imdang/data/repository/AuthRepositoryImpl.kt
@@ -4,8 +4,10 @@ import info.imdang.data.datasource.lcoal.AuthLocalDataSource
 import info.imdang.data.datasource.remote.AuthRemoteDataSource
 import info.imdang.data.model.request.auth.LoginRequest
 import info.imdang.data.model.request.auth.OnboardingRequest
+import info.imdang.data.model.request.auth.ReissueTokenRequest
 import info.imdang.domain.model.auth.LoginDto
 import info.imdang.domain.model.auth.OnboardingDto
+import info.imdang.domain.model.auth.TokenDto
 import info.imdang.domain.repository.AuthRepository
 import javax.inject.Inject
 
@@ -43,6 +45,14 @@ internal class AuthRepositoryImpl @Inject constructor(
             onboardingRequest = OnboardingRequest.fromDomain(onboardingRequest)
         )
     }
+
+    override suspend fun reissueToken(memberId: String, refreshToken: String): TokenDto? =
+        authRemoteDataSource.reissueToken(
+            ReissueTokenRequest(
+                memberId = memberId,
+                refreshToken = refreshToken
+            )
+        )?.mapper()
 
     override fun saveMemberId(memberId: String) {
         authLocalDataSource.saveMemberId(memberId)

--- a/domain/src/main/java/info/imdang/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/info/imdang/domain/repository/AuthRepository.kt
@@ -2,6 +2,7 @@ package info.imdang.domain.repository
 
 import info.imdang.domain.model.auth.LoginDto
 import info.imdang.domain.model.auth.OnboardingDto
+import info.imdang.domain.model.auth.TokenDto
 
 interface AuthRepository {
 
@@ -20,6 +21,8 @@ interface AuthRepository {
     suspend fun removeToken()
 
     suspend fun onboardingJoin(onboardingRequest: OnboardingDto)
+
+    suspend fun reissueToken(memberId: String, refreshToken: String): TokenDto?
 
     fun saveMemberId(memberId: String)
 

--- a/domain/src/main/java/info/imdang/domain/usecase/auth/ReissueTokenUseCase.kt
+++ b/domain/src/main/java/info/imdang/domain/usecase/auth/ReissueTokenUseCase.kt
@@ -15,7 +15,7 @@ class ReissueTokenUseCase @Inject constructor(
     override suspend fun execute(parameters: Unit): TokenDto? {
         val tokenDto = repository.reissueToken(
             memberId = repository.getMemberId(),
-            refreshToken = repository.getRefreshToken(),
+            refreshToken = repository.getRefreshToken()
         )
         tokenDto?.let {
             repository.saveAccessToken(tokenDto.accessToken)

--- a/domain/src/main/java/info/imdang/domain/usecase/auth/ReissueTokenUseCase.kt
+++ b/domain/src/main/java/info/imdang/domain/usecase/auth/ReissueTokenUseCase.kt
@@ -1,0 +1,26 @@
+package info.imdang.domain.usecase.auth
+
+import info.imdang.domain.IoDispatcher
+import info.imdang.domain.model.auth.TokenDto
+import info.imdang.domain.repository.AuthRepository
+import info.imdang.domain.usecase.UseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Inject
+
+class ReissueTokenUseCase @Inject constructor(
+    private val repository: AuthRepository,
+    @IoDispatcher dispatcher: CoroutineDispatcher
+) : UseCase<Unit, TokenDto?>(coroutineDispatcher = dispatcher) {
+
+    override suspend fun execute(parameters: Unit): TokenDto? {
+        val tokenDto = repository.reissueToken(
+            memberId = repository.getMemberId(),
+            refreshToken = repository.getRefreshToken(),
+        )
+        tokenDto?.let {
+            repository.saveAccessToken(tokenDto.accessToken)
+            repository.saveRefreshToken(tokenDto.refreshToken)
+        }
+        return tokenDto
+    }
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
- resolve #104

## 🖥️ 작업 내용
- 토큰 갱신 로직 수정

## ℹ️ 참고 사항
- NetworkModule에서 토큰을 갱신하면 여러개의 api 처리가 잘 안돼서 앱 진입 시 무조건 토큰을 갱신하도록 수정했습니다.
